### PR TITLE
Provide an helper method that can be used to parse both versions of OPDS feeds

### DIFF
--- a/readium-opds.xcodeproj/project.pbxproj
+++ b/readium-opds.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		111E54CD201BBD9700A7FE9A /* wiki_1_1.opds in Resources */ = {isa = PBXBuildFile; fileRef = 111E54CC201BBD9700A7FE9A /* wiki_1_1.opds */; };
-		111E54CE201BC50E00A7FE9A /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B7E681FA35BB100534FD3 /* OPDSParser.swift */; };
+		111E54CE201BC50E00A7FE9A /* OPDS1Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B7E681FA35BB100534FD3 /* OPDS1Parser.swift */; };
 		111E54D0201BC52600A7FE9A /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F34B7E6B1FA35CEA00534FD3 /* R2Shared.framework */; };
 		111E54D5201FB0AD00A7FE9A /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 111E54D4201FB0AC00A7FE9A /* PromiseKit.framework */; };
 		111E54D6201FB0B600A7FE9A /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 111E54D4201FB0AC00A7FE9A /* PromiseKit.framework */; };
@@ -17,12 +17,13 @@
 		111E54DD2021022700A7FE9A /* OPDS2Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111E54DB2021022700A7FE9A /* OPDS2Parser.swift */; };
 		111E54DF2022812B00A7FE9A /* opds_2_0.json in Resources */ = {isa = PBXBuildFile; fileRef = 111E54DE2022812B00A7FE9A /* opds_2_0.json */; };
 		111E54E12022816000A7FE9A /* readium_opds2_0_test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111E54E02022816000A7FE9A /* readium_opds2_0_test.swift */; };
-		AED681F020A316160090DBCD /* URLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED681EF20A316160090DBCD /* URLHelper.swift */; };
 		AE0AC4A620AB1F8B00B2FC36 /* Fuzi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE0AC4A520AB1F8B00B2FC36 /* Fuzi.framework */; };
+		AE6B98E020CAB93200117197 /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6B98DF20CAB93200117197 /* OPDSParser.swift */; };
+		AED681F020A316160090DBCD /* URLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED681EF20A316160090DBCD /* URLHelper.swift */; };
 		F34B7E571FA35B7900534FD3 /* ReadiumOPDS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F34B7E4D1FA35B7900534FD3 /* ReadiumOPDS.framework */; };
 		F34B7E5C1FA35B7900534FD3 /* readium_opds1_1_test.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B7E5B1FA35B7900534FD3 /* readium_opds1_1_test.swift */; };
 		F34B7E5E1FA35B7900534FD3 /* readium_opds.h in Headers */ = {isa = PBXBuildFile; fileRef = F34B7E501FA35B7900534FD3 /* readium_opds.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F34B7E691FA35BB100534FD3 /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B7E681FA35BB100534FD3 /* OPDSParser.swift */; };
+		F34B7E691FA35BB100534FD3 /* OPDS1Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = F34B7E681FA35BB100534FD3 /* OPDS1Parser.swift */; };
 		F34B7E701FA3771E00534FD3 /* R2Shared.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F34B7E6B1FA35CEA00534FD3 /* R2Shared.framework */; };
 /* End PBXBuildFile section */
 
@@ -43,15 +44,16 @@
 		111E54DB2021022700A7FE9A /* OPDS2Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDS2Parser.swift; sourceTree = "<group>"; };
 		111E54DE2022812B00A7FE9A /* opds_2_0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = opds_2_0.json; path = "readium-opdsTests/Samples/opds_2_0.json"; sourceTree = SOURCE_ROOT; };
 		111E54E02022816000A7FE9A /* readium_opds2_0_test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = readium_opds2_0_test.swift; sourceTree = "<group>"; };
-		AED681EF20A316160090DBCD /* URLHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLHelper.swift; sourceTree = "<group>"; };
 		AE0AC4A520AB1F8B00B2FC36 /* Fuzi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fuzi.framework; path = Carthage/Build/iOS/Fuzi.framework; sourceTree = "<group>"; };
+		AE6B98DF20CAB93200117197 /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
+		AED681EF20A316160090DBCD /* URLHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLHelper.swift; sourceTree = "<group>"; };
 		F34B7E4D1FA35B7900534FD3 /* ReadiumOPDS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReadiumOPDS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F34B7E501FA35B7900534FD3 /* readium_opds.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = readium_opds.h; sourceTree = "<group>"; };
 		F34B7E511FA35B7900534FD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F34B7E561FA35B7900534FD3 /* readium-opdsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "readium-opdsTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		F34B7E5B1FA35B7900534FD3 /* readium_opds1_1_test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = readium_opds1_1_test.swift; sourceTree = "<group>"; };
 		F34B7E5D1FA35B7900534FD3 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F34B7E681FA35BB100534FD3 /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
+		F34B7E681FA35BB100534FD3 /* OPDS1Parser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDS1Parser.swift; sourceTree = "<group>"; };
 		F34B7E6B1FA35CEA00534FD3 /* R2Shared.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = R2Shared.framework; path = Carthage/Build/iOS/R2Shared.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -113,7 +115,8 @@
 			children = (
 				F34B7E501FA35B7900534FD3 /* readium_opds.h */,
 				F34B7E511FA35B7900534FD3 /* Info.plist */,
-				F34B7E681FA35BB100534FD3 /* OPDSParser.swift */,
+				AE6B98DF20CAB93200117197 /* OPDSParser.swift */,
+				F34B7E681FA35BB100534FD3 /* OPDS1Parser.swift */,
 				111E54DB2021022700A7FE9A /* OPDS2Parser.swift */,
 				AED681EF20A316160090DBCD /* URLHelper.swift */,
 			);
@@ -281,7 +284,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				AED681F020A316160090DBCD /* URLHelper.swift in Sources */,
-				F34B7E691FA35BB100534FD3 /* OPDSParser.swift in Sources */,
+				F34B7E691FA35BB100534FD3 /* OPDS1Parser.swift in Sources */,
+				AE6B98E020CAB93200117197 /* OPDSParser.swift in Sources */,
 				111E54DC2021022700A7FE9A /* OPDS2Parser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -292,7 +296,7 @@
 			files = (
 				111E54DD2021022700A7FE9A /* OPDS2Parser.swift in Sources */,
 				111E54E12022816000A7FE9A /* readium_opds2_0_test.swift in Sources */,
-				111E54CE201BC50E00A7FE9A /* OPDSParser.swift in Sources */,
+				111E54CE201BC50E00A7FE9A /* OPDS1Parser.swift in Sources */,
 				F34B7E5C1FA35B7900534FD3 /* readium_opds1_1_test.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/readium-opds/OPDS1Parser.swift
+++ b/readium-opds/OPDS1Parser.swift
@@ -1,0 +1,519 @@
+//
+//  OPDS1Parser.swift
+//  readium-opds
+//
+//  Created by Alexandre Camilleri on 10/27/17.
+//  Copyright © 2017 Readium. All rights reserved.
+//
+
+import Fuzi
+import R2Shared
+import PromiseKit
+
+public enum OPDS1ParserError: Error {
+    case missingTitle
+    case rootNotFound
+    
+    var localizedDescription: String {
+        switch self {
+        case .missingTitle:
+            return "The title is missing from the feed."
+        case .rootNotFound:
+            return "Root is not found"
+        }
+    }
+}
+
+public enum OPDSParserOpenSearchHelperError: Error {
+    case searchLinkNotFound
+    case searchDocumentIsInvalid
+//    case missingTemplateForFeedType
+
+    var localizedDescription: String {
+        switch self {
+        case .searchLinkNotFound:
+            return "Search link not found in feed"
+        case .searchDocumentIsInvalid:
+            return "OpenSearch document is invalid"
+//        case .missingTemplateForFeedType:
+//            return "Missing search template for feed type"
+        }
+    }
+}
+
+struct MimeTypeParameters {
+    var type: String
+    var parameters = [String: String]()
+}
+
+public class OPDS1Parser {
+    static var feedURL: URL?
+    
+    /// Parse an OPDS feed.
+    /// Feed can only be v1 (XML).
+    /// - parameter url: The feed URL
+    /// - Returns: A promise with the resulting Feed
+    public static func parseURL(url: URL) -> Promise<Feed> {
+        feedURL = url
+        
+        return Promise<Feed> {fulfill, reject in
+            let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, response, error) in
+                guard error == nil else {
+                    reject(error!)
+                    return
+                }
+                guard let data = data else {
+                    reject(OPDSParserError.documentNotFound)
+                    return
+                }
+                do {
+                    let feed = try self.parse(xmlData: data)
+                    fulfill(feed)
+                }
+                catch {
+                    reject(error)
+                }
+
+            })
+            task.resume()
+        }
+    }
+
+    /// Parse an OPDS feed.
+    /// Feed can only be v1 (XML).
+    /// - parameter xmlData: The xml raw data
+    /// - Returns: The resulting Feed
+    public static func parse(xmlData: Data) throws -> Feed {
+        let document = try XMLDocument.init(data: xmlData)
+        
+        document.definePrefix("thr", defaultNamespace: "http://purl.org/syndication/thread/1.0")
+        document.definePrefix("dcterms", defaultNamespace: "http://purl.org/dc/terms/")
+        document.definePrefix("opds", defaultNamespace: "http://opds-spec.org/2010/catalog")
+        
+        guard let root = document.root else {
+            throw OPDS1ParserError.rootNotFound
+        }
+
+        guard let title = root.firstChild(tag: "title")?.stringValue else {
+            throw OPDS1ParserError.missingTitle
+        }
+        let feed = Feed.init(title: title)
+
+        if let tmpDate = root.firstChild(tag: "updated")?.stringValue,
+            let date = tmpDate.dateFromISO8601
+        {
+            feed.metadata.modified = date
+        }
+        if let totalResults = root.firstChild(tag: "TotalResults")?.stringValue {
+            feed.metadata.numberOfItem = Int(totalResults)
+        }
+        if let itemsPerPage = root.firstChild(tag: "ItemsPerPage")?.stringValue {
+            feed.metadata.itemsPerPage = Int(itemsPerPage)
+        }
+
+        for entry in root.children(tag: "entry") {
+            var isNavigation = true
+            let collectionLink = Link()
+
+            for link in entry.children(tag: "link") {
+                if let rel = link.attributes["rel"] {
+                    // Check is navigation or acquisition.
+                    if rel.range(of: "http://opds-spec.org/acquisition") != nil {
+                        isNavigation = false
+                    }
+                    // Check if there is a colelction.
+                    if rel == "collection" || rel == "http://opds-spec.org/group" {
+                        collectionLink.rel.append("collection")
+                        collectionLink.href = link.attributes["href"]
+                        collectionLink.absoluteHref = URLHelper.getAbsolute(href: link.attributes["href"], base: feedURL)
+                        collectionLink.title = link.attributes["title"]
+                    }
+                }
+            }
+
+            if (!isNavigation) {
+                let publication = parseEntry(entry: entry)
+
+                // Checking if this publication need to go into a group or in publications.
+                if collectionLink.href != nil {
+                    addPublicationInGroup(feed, publication, collectionLink)
+                } else {
+                    feed.publications.append(publication)
+                }
+            } else {
+                let newLink = Link()
+
+                if let entryTitle = entry.firstChild(tag: "title")?.stringValue {
+                    newLink.title = entryTitle
+                }
+                
+                if let rel = entry.firstChild(tag: "link")?.attr("rel") {
+                    newLink.rel.append(rel)
+                }
+                
+                if let facetElementCountStr = entry.firstChild(tag: "link")?.attr("count"),
+                    let facetElementCount = Int(facetElementCountStr) {
+                    newLink.properties.numberOfItems = facetElementCount
+                }
+                
+                newLink.typeLink = entry.firstChild(tag: "link")?.attr("type")
+                newLink.href = entry.firstChild(tag: "link")?.attr("href")
+                newLink.absoluteHref = URLHelper.getAbsolute(href: entry.firstChild(tag: "link")?.attr("href"), base: feedURL)
+                
+                // Check collection link
+                if collectionLink.href != nil {
+                    addNavigationInGroup(feed, newLink, collectionLink)
+                } else {
+                    feed.navigation.append(newLink)
+                }
+            }
+        }
+
+        for link in root.children(tag: "link") {
+            let newLink = Link()
+
+            newLink.href = link.attributes["href"]
+            newLink.absoluteHref = URLHelper.getAbsolute(href: link.attributes["href"], base: feedURL)
+            newLink.title = link.attributes["title"]
+            newLink.typeLink = link.attributes["type"]
+            if let rel = link.attributes["rel"] {
+                newLink.rel.append(rel)
+            }
+            //                    if let rels = link.attributes["rel"]?.split(separator: " ") {
+            //                        for rel in rels {
+            //                            newLink.rel.append(rel)
+            //                        }
+            //                    }
+            if let facetGroupName = link.attributes["facetGroup"],
+                newLink.rel.contains("http://opds-spec.org/facet")
+            {
+                if let facetElementCountStr = link.attributes["count"],
+                    let facetElementCount = Int(facetElementCountStr) {
+                    newLink.properties.numberOfItems = facetElementCount
+                }
+                addFacet(feed: feed, to: newLink, named: facetGroupName)
+            } else {
+                feed.links.append(newLink)
+            }
+        }
+        
+        return feed
+    }
+
+    public static func parseEntry(xmlData: Data) throws -> Publication {
+        let document = try XMLDocument.init(data: xmlData)
+        guard let root = document.root else {
+            throw OPDS1ParserError.rootNotFound
+        }
+        return parseEntry(entry: root)
+    }
+
+    static func parseMimeType(mimeTypeString: String) -> MimeTypeParameters {
+        let substrings = mimeTypeString.split(separator: ";")
+        let type = String(substrings[0]).trimmingCharacters(in: .whitespaces)
+        var params = [String: String]()
+        for defn in substrings.dropFirst() {
+            let halves = defn.split(separator: "=")
+            let paramName = String(halves[0]).trimmingCharacters(in: .whitespaces)
+            let paramValue = String(halves[1]).trimmingCharacters(in: .whitespaces)
+            params[paramName] = paramValue
+        }
+        return MimeTypeParameters(type: type, parameters: params)
+    }
+
+    public static func fetchOpenSearchTemplate(feed: Feed) -> Promise<String> {
+        return Promise<String> { fulfill, reject in
+            var openSearchURL: URL? = nil
+            var selfMimeType: String? = nil
+
+            for link in feed.links {
+                if link.rel[0] == "self" {
+                    if let linkType = link.typeLink {
+                        selfMimeType = linkType
+                        if openSearchURL != nil {
+                            break
+                        }
+                    }
+                }
+                else if link.rel[0] == "search" {
+                    guard let linkHref = link.href else {
+                        reject(OPDSParserOpenSearchHelperError.searchLinkNotFound)
+                        return
+                    }
+                    openSearchURL = URL(string: linkHref)
+                    if selfMimeType != nil {
+                        break
+                    }
+                }
+            }
+
+            guard let unwrappedURL = openSearchURL else {
+                reject(OPDSParserOpenSearchHelperError.searchLinkNotFound)
+                return
+            }
+
+            URLSession.shared.dataTask(with: unwrappedURL, completionHandler: { (data, response, error) in
+                guard error == nil else {
+                    reject(error!)
+                    return
+                }
+                guard let data = data else {
+                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
+                    return
+                }
+                guard let document = try? XMLDocument.init(data: data) else {
+                    reject (OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
+                    return
+                }
+                guard let urls = document.root?.children(tag: "Url") else {
+                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
+                    return
+                }
+                if urls.count == 0 {
+                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
+                    return
+                }
+                // The OpenSearch document may contain multiple Urls, and we need to find the closest matching one.
+                // We match by mimetype and profile; if that fails, by mimetype; and if that fails, the first url is returned
+                var typeAndProfileMatch: XMLElement? = nil
+                var typeMatch: XMLElement? = nil
+                if let unwrappedSelfMimeType = selfMimeType {
+                    let selfMimeParams = parseMimeType(mimeTypeString: unwrappedSelfMimeType)
+                    for url in urls {
+                        guard let urlMimeType = url.attributes["type"] else {
+                            continue
+                        }
+                        let otherMimeParams = parseMimeType(mimeTypeString: urlMimeType)
+                        if selfMimeParams.type == otherMimeParams.type {
+                            if typeMatch == nil {
+                                typeMatch = url
+                            }
+                            if selfMimeParams.parameters["profile"] == otherMimeParams.parameters["profile"] {
+                                typeAndProfileMatch = url
+                                break
+                            }
+                        }
+                    }
+                }
+                let match = typeAndProfileMatch ?? (typeMatch ?? urls[0])
+                guard let template = match.attributes["template"] else {
+                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
+                    return
+                }
+                fulfill(template)
+                return
+            }).resume()
+        }
+    }
+
+    static internal func parseEntry(entry: XMLElement) -> Publication {
+        let publication = Publication()
+        /// METADATA (publication) ----
+        let metadata = Metadata()
+        publication.metadata = metadata
+
+        if let entryTitle = entry.firstChild(tag: "title")?.stringValue {
+            if metadata.multilangTitle == nil {
+                metadata.multilangTitle = MultilangString()
+            }
+            metadata.multilangTitle?.singleString = entryTitle
+        }
+
+        if let identifier = entry.firstChild(tag: "identifier")?.stringValue {
+            metadata.identifier = identifier
+        } else if let id = entry.firstChild(tag: "id")?.stringValue {
+            metadata.identifier = id
+        }
+
+        // Languages.
+        let languages = entry.children(tag: "language")
+        if languages.count > 0 {
+            metadata.languages = languages.map({ $0.stringValue })
+        }
+        // Last modification date.
+        if let tmpDate = entry.firstChild(tag: "updated")?.stringValue,
+            let date = tmpDate.dateFromISO8601
+        {
+            metadata.modified = date
+        }
+        // Publication date.
+        if let tmpDate = entry.firstChild(tag: "published")?.stringValue {
+            metadata.publicationDate = tmpDate
+        }
+
+        // Rights.
+        let rights = entry.children(tag: "rights")
+        if rights.count > 0 {
+            metadata.rights = rights.map({ $0.stringValue }).joined(separator: " ")
+        }
+        // TODO SERIES -------------
+        // Publisher
+        if let publisher = entry.firstChild(tag: "publisher")?.stringValue {
+            let contributor = Contributor()
+
+            contributor.multilangName.singleString = publisher
+            metadata.publishers.append(contributor)
+        }
+        // Categories.
+        for category in entry.children(tag: "category") {
+            let subject = Subject()
+
+            subject.code = category.attributes["term"]
+            subject.name = category.attributes["label"]
+            subject.scheme = category.attributes["scheme"]
+            metadata.subjects.append(subject)
+        }
+        /// Contributors.
+        // Author.
+        for author in entry.children(tag: "author") {
+            let contributor = Contributor()
+
+            if let uri = author.firstChild(tag: "uri")?.stringValue {
+                let link = Link()
+                link.href = uri
+                link.absoluteHref = URLHelper.getAbsolute(href: uri, base: feedURL)
+                contributor.links.append(link)
+            }
+            
+            contributor.multilangName.singleString = author.firstChild(tag: "name")?.stringValue
+            metadata.authors.append(contributor)
+        }
+        // Description.
+        if let content = entry.firstChild(tag: "content")?.stringValue {
+            metadata.description = content
+        } else if let summary = entry.firstChild(tag: "summary")?.stringValue {
+            metadata.description = summary
+        }
+        // Links.
+        for link in entry.children(tag: "link") {
+            let newLink = Link()
+
+            newLink.href = link.attributes["href"]
+            newLink.absoluteHref = URLHelper.getAbsolute(href: link.attributes["href"], base: feedURL)
+            newLink.title = link.attributes["title"]
+            newLink.typeLink = link.attributes["type"]
+            if let rel = link.attributes["rel"] {
+                newLink.rel.append(rel)
+            }
+            //                            if let rels = link.attributes["rel"]?.split(separator: " ") {
+            //                                for rel in rels {
+            //                                    newLink.rel.append(rel)
+            //                                }
+            //                            }
+            // Indirect acquisition check. (Recursive)
+            let indirectAcquisitions = link.children(tag: "indirectAcquisition")
+            if !indirectAcquisitions.isEmpty {
+                newLink.properties.indirectAcquisition = parseIndirectAcquisition(children: indirectAcquisitions)
+            }
+            // Price.
+            if let price = link.firstChild(tag: "price")?.stringValue,
+                let priceDouble = Double(price),
+                let currency = link.firstChild(tag: "price")?.attr("currencyCode")
+            {
+                let newPrice = Price(currency: currency, value: priceDouble)
+
+                newLink.properties.price = newPrice
+            }
+            if let rel = link.attributes["rel"] {
+                if rel == "collection" || rel == "http://opds-spec.org/group" {
+                } else if rel == "http://opds-spec.org/image" || rel == "http://opds-spec.org/image-thumbnail" {
+                    publication.images.append(newLink)
+                } else {
+                    publication.links.append(newLink)
+                }
+            }
+        }
+
+        return publication
+    }
+
+    static internal func addFacet(feed: Feed, to link: Link, named title: String) {
+        for facet in feed.facets {
+            if facet.metadata.title == title {
+                facet.links.append(link)
+                return
+            }
+        }
+        let newFacet = Facet(title: title)
+
+        newFacet.links.append(link)
+        feed.facets.append(newFacet)
+    }
+
+    static internal func addPublicationInGroup(_ feed: Feed,
+                                               _ publication: Publication,
+                                               _ collectionLink: Link)
+    {
+        for group in feed.groups {
+            for l in group.links {
+                if l.href == collectionLink.href {
+                    group.publications.append(publication)
+                    return
+                }
+            }
+        }
+        if let title = collectionLink.title {
+            let newGroup = Group.init(title: title)
+            let selfLink = Link()
+
+            selfLink.href = collectionLink.href
+            selfLink.absoluteHref = URLHelper.getAbsolute(href: selfLink.href, base: feedURL)
+            selfLink.title = collectionLink.title
+            selfLink.rel.append("self")
+            newGroup.links.append(selfLink)
+            //
+            newGroup.publications.append(publication)
+            //
+            feed.groups.append(newGroup)
+        }
+    }
+
+    static internal func addNavigationInGroup(_ feed: Feed,
+                                              _ link: Link,
+                                              _ collectionLink: Link)
+    {
+        for group in feed.groups {
+            for l in group.links {
+                if l.href == collectionLink.href {
+                    group.navigation.append(link)
+                    return
+                }
+            }
+        }
+        if let title = collectionLink.title {
+            let newGroup = Group.init(title: title)
+            let selfLink = Link()
+
+            selfLink.href = collectionLink.href
+            selfLink.absoluteHref = URLHelper.getAbsolute(href: collectionLink.href, base: feedURL)
+            selfLink.title = collectionLink.title
+            selfLink.rel.append("self")
+            newGroup.links.append(selfLink)
+            //
+            newGroup.navigation.append(link)
+            //
+            feed.groups.append(newGroup)
+        }
+    }
+
+    /// <#Description#>
+    ///
+    /// - Parameter children: <#children description#>
+    /// - Returns: <#return value description#>
+    static internal func parseIndirectAcquisition(children: [XMLElement]) -> [IndirectAcquisition] {
+        var ret = [IndirectAcquisition]()
+
+        for child in children {
+            if let typeAcquisition = child.attributes["type"] {
+                let newIndAcq = IndirectAcquisition(typeAcquisition: typeAcquisition)
+
+                let grandChildren = child.children(tag: "indirectAcquisition")
+                if grandChildren.count > 0 {
+                    newIndAcq.child = parseIndirectAcquisition(children: grandChildren)
+                }
+                ret.append(newIndAcq)
+            }
+        }
+        return ret
+    }
+}

--- a/readium-opds/OPDS2Parser.swift
+++ b/readium-opds/OPDS2Parser.swift
@@ -58,6 +58,10 @@ public enum OPDS2ParserError: Error {
 public class OPDS2Parser {
   static var feedURL: URL?
     
+  /// Parse an OPDS feed.
+  /// Feed can only be v2 (JSON).
+  /// - parameter url: The feed URL
+  /// - Returns: A promise with the resulting Feed
   public static func parseURL(url: URL) -> Promise<Feed> {
         feedURL = url
     
@@ -72,65 +76,7 @@ public class OPDS2Parser {
               return
             }
             do {
-              
-              guard let jsonRoot = try? JSONSerialization.jsonObject(with: data, options: []) else {
-                throw OPDS2ParserError.invalidJSON
-              }
-              guard let topLevelDict = jsonRoot as? [String: Any] else {
-                throw OPDS2ParserError.invalidJSON
-              }
-              guard let metadataDict = topLevelDict["metadata"] as? [String: Any] else {
-                throw OPDS2ParserError.metadataNotFound
-                
-              }
-              guard let title = metadataDict["title"] as? String else {
-                throw OPDS2ParserError.missingTitle
-              }
-              let feed = Feed(title: title)
-              parseMetadata(opdsMetadata: feed.metadata, metadataDict: metadataDict)
-              
-              for (k, v) in topLevelDict {
-                switch k {
-                case "@context":
-                  switch v {
-                  case let s as String:
-                    feed.context.append(s)
-                  case let sArr as [String]:
-                    feed.context.append(contentsOf: sArr)
-                  default:
-                    continue
-                  }
-                case "metadata": // Already handled above
-                  continue
-                case "links":
-                  guard let links = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidLink
-                  }
-                  try parseLinks(feed: feed, links: links)
-                case "facets":
-                  guard let facets = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidFacet
-                  }
-                  try parseFacets(feed: feed, facets: facets)
-                case "publications":
-                  guard let publications = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidPublication
-                  }
-                  try parsePublications(feed: feed, publications: publications)
-                case "navigation":
-                  guard let navLinks = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidNavigation
-                  }
-                  try parseNavigation(feed: feed, navLinks: navLinks)
-                case "groups":
-                  guard let groups = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidGroup
-                  }
-                  try parseGroups(feed: feed, groups: groups)
-                default:
-                  continue
-                }
-              }
+              let feed = try self.parse(jsonData: data)
               fulfill(feed)
             }
             catch {
@@ -141,6 +87,80 @@ public class OPDS2Parser {
           task.resume()
         }
     }
+    
+    /// Parse an OPDS feed.
+    /// Feed can only be v2 (JSON).
+    /// - parameter jsonData: The json raw data
+    /// - Returns: The resulting Feed
+    public static func parse(jsonData: Data) throws -> Feed {
+        
+        guard let jsonRoot = try? JSONSerialization.jsonObject(with: jsonData, options: []) else {
+            throw OPDS2ParserError.invalidJSON
+        }
+        
+        guard let topLevelDict = jsonRoot as? [String: Any] else {
+            throw OPDS2ParserError.invalidJSON
+        }
+        
+        guard let metadataDict = topLevelDict["metadata"] as? [String: Any] else {
+            throw OPDS2ParserError.metadataNotFound
+            
+        }
+        
+        guard let title = metadataDict["title"] as? String else {
+            throw OPDS2ParserError.missingTitle
+        }
+        
+        let feed = Feed(title: title)
+        parseMetadata(opdsMetadata: feed.metadata, metadataDict: metadataDict)
+        
+        for (k, v) in topLevelDict {
+            switch k {
+            case "@context":
+                switch v {
+                case let s as String:
+                    feed.context.append(s)
+                case let sArr as [String]:
+                    feed.context.append(contentsOf: sArr)
+                default:
+                    continue
+                }
+            case "metadata": // Already handled above
+                continue
+            case "links":
+                guard let links = v as? [[String: Any]] else {
+                    throw OPDS2ParserError.invalidLink
+                }
+                try parseLinks(feed: feed, links: links)
+            case "facets":
+                guard let facets = v as? [[String: Any]] else {
+                    throw OPDS2ParserError.invalidFacet
+                }
+                try parseFacets(feed: feed, facets: facets)
+            case "publications":
+                guard let publications = v as? [[String: Any]] else {
+                    throw OPDS2ParserError.invalidPublication
+                }
+                try parsePublications(feed: feed, publications: publications)
+            case "navigation":
+                guard let navLinks = v as? [[String: Any]] else {
+                    throw OPDS2ParserError.invalidNavigation
+                }
+                try parseNavigation(feed: feed, navLinks: navLinks)
+            case "groups":
+                guard let groups = v as? [[String: Any]] else {
+                    throw OPDS2ParserError.invalidGroup
+                }
+                try parseGroups(feed: feed, groups: groups)
+            default:
+                continue
+            }
+        }
+        
+        return feed
+        
+    }
+
 
     static internal func parseMetadata(opdsMetadata: OpdsMetadata, metadataDict: [String: Any]) {
         for (k, v) in metadataDict {

--- a/readium-opds/OPDSParser.swift
+++ b/readium-opds/OPDSParser.swift
@@ -2,516 +2,76 @@
 //  OPDSParser.swift
 //  readium-opds
 //
-//  Created by Alexandre Camilleri on 10/27/17.
-//  Copyright © 2017 Readium. All rights reserved.
+//  Created by Geoffrey Bugniot on 22/05/2018.
+//  Copyright © 2018 Readium. All rights reserved.
 //
 
-import Fuzi
-import R2Shared
+import Foundation
 import PromiseKit
+import R2Shared
 
 public enum OPDSParserError: Error {
-    case missingTitle
+    
     case documentNotFound
-    case rootNotFound
+    case documentNotValid
     
     var localizedDescription: String {
         switch self {
-        case .missingTitle:
-            return "The title is missing from the feed."
         case .documentNotFound:
             return "Document is not found"
-        case .rootNotFound:
-            return "Root is not found"
+        case .documentNotValid:
+            return "Document is not valid"
         }
     }
-}
-
-public enum OPDSParserOpenSearchHelperError: Error {
-    case searchLinkNotFound
-    case searchDocumentIsInvalid
-//    case missingTemplateForFeedType
-
-    var localizedDescription: String {
-        switch self {
-        case .searchLinkNotFound:
-            return "Search link not found in feed"
-        case .searchDocumentIsInvalid:
-            return "OpenSearch document is invalid"
-//        case .missingTemplateForFeedType:
-//            return "Missing search template for feed type"
-        }
-    }
-}
-
-struct MimeTypeParameters {
-    var type: String
-    var parameters = [String: String]()
+    
 }
 
 public class OPDSParser {
+    
     static var feedURL: URL?
     
+    /// Parse an OPDS feed.
+    /// Feed can be v1 (XML) or v2 (JSON).
+    /// - parameter url: The feed URL
+    /// - Returns: A promise with the resulting Feed
     public static func parseURL(url: URL) -> Promise<Feed> {
         feedURL = url
         
         return Promise<Feed> {fulfill, reject in
+            
             let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, response, error) in
+                
+                // Basically, catch networking errors
                 guard error == nil else {
                     reject(error!)
                     return
                 }
+                
+                // Ressource not found
                 guard let data = data else {
                     reject(OPDSParserError.documentNotFound)
                     return
                 }
-                do {
-                    let feed = try self.parse(xmlData: data)
+                
+                // We try to parse as an OPDS v1 feed,
+                // then, if it fails, we try as an OPDS v2 feed.
+                if let feed = try? OPDS1Parser.parse(xmlData: data) {
                     fulfill(feed)
+                } else {
+                    if let feed = try? OPDS2Parser.parse(jsonData: data) {
+                        fulfill(feed)
+                    } else {
+                        // Not a valid OPDS ressource
+                        reject(OPDSParserError.documentNotValid)
+                    }
                 }
-                catch {
-                    reject(error)
-                }
-
+                
             })
-            task.resume()
-        }
-    }
-
-    /// Parse an OPDS flux.
-    ///
-    /// - Parameter: The opds flux data.
-    public static func parse(xmlData: Data) throws -> Feed {
-        let document = try XMLDocument.init(data: xmlData)
-        
-        document.definePrefix("thr", defaultNamespace: "http://purl.org/syndication/thread/1.0")
-        document.definePrefix("dcterms", defaultNamespace: "http://purl.org/dc/terms/")
-        document.definePrefix("opds", defaultNamespace: "http://opds-spec.org/2010/catalog")
-        
-        guard let root = document.root else {
-            throw OPDSParserError.rootNotFound
-        }
-
-        guard let title = root.firstChild(tag: "title")?.stringValue else {
-            throw OPDSParserError.missingTitle
-        }
-        let feed = Feed.init(title: title)
-
-        if let tmpDate = root.firstChild(tag: "updated")?.stringValue,
-            let date = tmpDate.dateFromISO8601
-        {
-            feed.metadata.modified = date
-        }
-        if let totalResults = root.firstChild(tag: "TotalResults")?.stringValue {
-            feed.metadata.numberOfItem = Int(totalResults)
-        }
-        if let itemsPerPage = root.firstChild(tag: "ItemsPerPage")?.stringValue {
-            feed.metadata.itemsPerPage = Int(itemsPerPage)
-        }
-
-        for entry in root.children(tag: "entry") {
-            var isNavigation = true
-            let collectionLink = Link()
-
-            for link in entry.children(tag: "link") {
-                if let rel = link.attributes["rel"] {
-                    // Check is navigation or acquisition.
-                    if rel.range(of: "http://opds-spec.org/acquisition") != nil {
-                        isNavigation = false
-                    }
-                    // Check if there is a colelction.
-                    if rel == "collection" || rel == "http://opds-spec.org/group" {
-                        collectionLink.rel.append("collection")
-                        collectionLink.href = link.attributes["href"]
-                        collectionLink.absoluteHref = URLHelper.getAbsolute(href: link.attributes["href"], base: feedURL)
-                        collectionLink.title = link.attributes["title"]
-                    }
-                }
-            }
-
-            if (!isNavigation) {
-                let publication = parseEntry(entry: entry)
-
-                // Checking if this publication need to go into a group or in publications.
-                if collectionLink.href != nil {
-                    addPublicationInGroup(feed, publication, collectionLink)
-                } else {
-                    feed.publications.append(publication)
-                }
-            } else {
-                let newLink = Link()
-
-                if let entryTitle = entry.firstChild(tag: "title")?.stringValue {
-                    newLink.title = entryTitle
-                }
-                
-                if let rel = entry.firstChild(tag: "link")?.attr("rel") {
-                    newLink.rel.append(rel)
-                }
-                
-                if let facetElementCountStr = entry.firstChild(tag: "link")?.attr("count"),
-                    let facetElementCount = Int(facetElementCountStr) {
-                    newLink.properties.numberOfItems = facetElementCount
-                }
-                
-                newLink.typeLink = entry.firstChild(tag: "link")?.attr("type")
-                newLink.href = entry.firstChild(tag: "link")?.attr("href")
-                newLink.absoluteHref = URLHelper.getAbsolute(href: entry.firstChild(tag: "link")?.attr("href"), base: feedURL)
-                
-                // Check collection link
-                if collectionLink.href != nil {
-                    addNavigationInGroup(feed, newLink, collectionLink)
-                } else {
-                    feed.navigation.append(newLink)
-                }
-            }
-        }
-
-        for link in root.children(tag: "link") {
-            let newLink = Link()
-
-            newLink.href = link.attributes["href"]
-            newLink.absoluteHref = URLHelper.getAbsolute(href: link.attributes["href"], base: feedURL)
-            newLink.title = link.attributes["title"]
-            newLink.typeLink = link.attributes["type"]
-            if let rel = link.attributes["rel"] {
-                newLink.rel.append(rel)
-            }
-            //                    if let rels = link.attributes["rel"]?.split(separator: " ") {
-            //                        for rel in rels {
-            //                            newLink.rel.append(rel)
-            //                        }
-            //                    }
-            if let facetGroupName = link.attributes["facetGroup"],
-                newLink.rel.contains("http://opds-spec.org/facet")
-            {
-                if let facetElementCountStr = link.attributes["count"],
-                    let facetElementCount = Int(facetElementCountStr) {
-                    newLink.properties.numberOfItems = facetElementCount
-                }
-                addFacet(feed: feed, to: newLink, named: facetGroupName)
-            } else {
-                feed.links.append(newLink)
-            }
-        }
-        
-        return feed
-    }
-
-    public static func parseEntry(xmlData: Data) throws -> Publication {
-        let document = try XMLDocument.init(data: xmlData)
-        guard let root = document.root else {
-            throw OPDSParserError.rootNotFound
-        }
-        return parseEntry(entry: root)
-    }
-
-    static func parseMimeType(mimeTypeString: String) -> MimeTypeParameters {
-        let substrings = mimeTypeString.split(separator: ";")
-        let type = String(substrings[0]).trimmingCharacters(in: .whitespaces)
-        var params = [String: String]()
-        for defn in substrings.dropFirst() {
-            let halves = defn.split(separator: "=")
-            let paramName = String(halves[0]).trimmingCharacters(in: .whitespaces)
-            let paramValue = String(halves[1]).trimmingCharacters(in: .whitespaces)
-            params[paramName] = paramValue
-        }
-        return MimeTypeParameters(type: type, parameters: params)
-    }
-
-    public static func fetchOpenSearchTemplate(feed: Feed) -> Promise<String> {
-        return Promise<String> { fulfill, reject in
-            var openSearchURL: URL? = nil
-            var selfMimeType: String? = nil
-
-            for link in feed.links {
-                if link.rel[0] == "self" {
-                    if let linkType = link.typeLink {
-                        selfMimeType = linkType
-                        if openSearchURL != nil {
-                            break
-                        }
-                    }
-                }
-                else if link.rel[0] == "search" {
-                    guard let linkHref = link.href else {
-                        reject(OPDSParserOpenSearchHelperError.searchLinkNotFound)
-                        return
-                    }
-                    openSearchURL = URL(string: linkHref)
-                    if selfMimeType != nil {
-                        break
-                    }
-                }
-            }
-
-            guard let unwrappedURL = openSearchURL else {
-                reject(OPDSParserOpenSearchHelperError.searchLinkNotFound)
-                return
-            }
-
-            URLSession.shared.dataTask(with: unwrappedURL, completionHandler: { (data, response, error) in
-                guard error == nil else {
-                    reject(error!)
-                    return
-                }
-                guard let data = data else {
-                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
-                    return
-                }
-                guard let document = try? XMLDocument.init(data: data) else {
-                    reject (OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
-                    return
-                }
-                guard let urls = document.root?.children(tag: "Url") else {
-                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
-                    return
-                }
-                if urls.count == 0 {
-                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
-                    return
-                }
-                // The OpenSearch document may contain multiple Urls, and we need to find the closest matching one.
-                // We match by mimetype and profile; if that fails, by mimetype; and if that fails, the first url is returned
-                var typeAndProfileMatch: XMLElement? = nil
-                var typeMatch: XMLElement? = nil
-                if let unwrappedSelfMimeType = selfMimeType {
-                    let selfMimeParams = parseMimeType(mimeTypeString: unwrappedSelfMimeType)
-                    for url in urls {
-                        guard let urlMimeType = url.attributes["type"] else {
-                            continue
-                        }
-                        let otherMimeParams = parseMimeType(mimeTypeString: urlMimeType)
-                        if selfMimeParams.type == otherMimeParams.type {
-                            if typeMatch == nil {
-                                typeMatch = url
-                            }
-                            if selfMimeParams.parameters["profile"] == otherMimeParams.parameters["profile"] {
-                                typeAndProfileMatch = url
-                                break
-                            }
-                        }
-                    }
-                }
-                let match = typeAndProfileMatch ?? (typeMatch ?? urls[0])
-                guard let template = match.attributes["template"] else {
-                    reject(OPDSParserOpenSearchHelperError.searchDocumentIsInvalid)
-                    return
-                }
-                fulfill(template)
-                return
-            }).resume()
-        }
-    }
-
-    static internal func parseEntry(entry: XMLElement) -> Publication {
-        let publication = Publication()
-        /// METADATA (publication) ----
-        let metadata = Metadata()
-        publication.metadata = metadata
-
-        if let entryTitle = entry.firstChild(tag: "title")?.stringValue {
-            if metadata.multilangTitle == nil {
-                metadata.multilangTitle = MultilangString()
-            }
-            metadata.multilangTitle?.singleString = entryTitle
-        }
-
-        if let identifier = entry.firstChild(tag: "identifier")?.stringValue {
-            metadata.identifier = identifier
-        } else if let id = entry.firstChild(tag: "id")?.stringValue {
-            metadata.identifier = id
-        }
-
-        // Languages.
-        let languages = entry.children(tag: "language")
-        if languages.count > 0 {
-            metadata.languages = languages.map({ $0.stringValue })
-        }
-        // Last modification date.
-        if let tmpDate = entry.firstChild(tag: "updated")?.stringValue,
-            let date = tmpDate.dateFromISO8601
-        {
-            metadata.modified = date
-        }
-        // Publication date.
-        if let tmpDate = entry.firstChild(tag: "published")?.stringValue {
-            metadata.publicationDate = tmpDate
-        }
-
-        // Rights.
-        let rights = entry.children(tag: "rights")
-        if rights.count > 0 {
-            metadata.rights = rights.map({ $0.stringValue }).joined(separator: " ")
-        }
-        // TODO SERIES -------------
-        // Publisher
-        if let publisher = entry.firstChild(tag: "publisher")?.stringValue {
-            let contributor = Contributor()
-
-            contributor.multilangName.singleString = publisher
-            metadata.publishers.append(contributor)
-        }
-        // Categories.
-        for category in entry.children(tag: "category") {
-            let subject = Subject()
-
-            subject.code = category.attributes["term"]
-            subject.name = category.attributes["label"]
-            subject.scheme = category.attributes["scheme"]
-            metadata.subjects.append(subject)
-        }
-        /// Contributors.
-        // Author.
-        for author in entry.children(tag: "author") {
-            let contributor = Contributor()
-
-            if let uri = author.firstChild(tag: "uri")?.stringValue {
-                let link = Link()
-                link.href = uri
-                link.absoluteHref = URLHelper.getAbsolute(href: uri, base: feedURL)
-                contributor.links.append(link)
-            }
             
-            contributor.multilangName.singleString = author.firstChild(tag: "name")?.stringValue
-            metadata.authors.append(contributor)
+            task.resume()
+            
         }
-        // Description.
-        if let content = entry.firstChild(tag: "content")?.stringValue {
-            metadata.description = content
-        } else if let summary = entry.firstChild(tag: "summary")?.stringValue {
-            metadata.description = summary
-        }
-        // Links.
-        for link in entry.children(tag: "link") {
-            let newLink = Link()
-
-            newLink.href = link.attributes["href"]
-            newLink.absoluteHref = URLHelper.getAbsolute(href: link.attributes["href"], base: feedURL)
-            newLink.title = link.attributes["title"]
-            newLink.typeLink = link.attributes["type"]
-            if let rel = link.attributes["rel"] {
-                newLink.rel.append(rel)
-            }
-            //                            if let rels = link.attributes["rel"]?.split(separator: " ") {
-            //                                for rel in rels {
-            //                                    newLink.rel.append(rel)
-            //                                }
-            //                            }
-            // Indirect acquisition check. (Recursive)
-            let indirectAcquisitions = link.children(tag: "indirectAcquisition")
-            if !indirectAcquisitions.isEmpty {
-                newLink.properties.indirectAcquisition = parseIndirectAcquisition(children: indirectAcquisitions)
-            }
-            // Price.
-            if let price = link.firstChild(tag: "price")?.stringValue,
-                let priceDouble = Double(price),
-                let currency = link.firstChild(tag: "price")?.attr("currencyCode")
-            {
-                let newPrice = Price(currency: currency, value: priceDouble)
-
-                newLink.properties.price = newPrice
-            }
-            if let rel = link.attributes["rel"] {
-                if rel == "collection" || rel == "http://opds-spec.org/group" {
-                } else if rel == "http://opds-spec.org/image" || rel == "http://opds-spec.org/image-thumbnail" {
-                    publication.images.append(newLink)
-                } else {
-                    publication.links.append(newLink)
-                }
-            }
-        }
-
-        return publication
+        
     }
-
-    static internal func addFacet(feed: Feed, to link: Link, named title: String) {
-        for facet in feed.facets {
-            if facet.metadata.title == title {
-                facet.links.append(link)
-                return
-            }
-        }
-        let newFacet = Facet(title: title)
-
-        newFacet.links.append(link)
-        feed.facets.append(newFacet)
-    }
-
-    static internal func addPublicationInGroup(_ feed: Feed,
-                                               _ publication: Publication,
-                                               _ collectionLink: Link)
-    {
-        for group in feed.groups {
-            for l in group.links {
-                if l.href == collectionLink.href {
-                    group.publications.append(publication)
-                    return
-                }
-            }
-        }
-        if let title = collectionLink.title {
-            let newGroup = Group.init(title: title)
-            let selfLink = Link()
-
-            selfLink.href = collectionLink.href
-            selfLink.absoluteHref = URLHelper.getAbsolute(href: selfLink.href, base: feedURL)
-            selfLink.title = collectionLink.title
-            selfLink.rel.append("self")
-            newGroup.links.append(selfLink)
-            //
-            newGroup.publications.append(publication)
-            //
-            feed.groups.append(newGroup)
-        }
-    }
-
-    static internal func addNavigationInGroup(_ feed: Feed,
-                                              _ link: Link,
-                                              _ collectionLink: Link)
-    {
-        for group in feed.groups {
-            for l in group.links {
-                if l.href == collectionLink.href {
-                    group.navigation.append(link)
-                    return
-                }
-            }
-        }
-        if let title = collectionLink.title {
-            let newGroup = Group.init(title: title)
-            let selfLink = Link()
-
-            selfLink.href = collectionLink.href
-            selfLink.absoluteHref = URLHelper.getAbsolute(href: collectionLink.href, base: feedURL)
-            selfLink.title = collectionLink.title
-            selfLink.rel.append("self")
-            newGroup.links.append(selfLink)
-            //
-            newGroup.navigation.append(link)
-            //
-            feed.groups.append(newGroup)
-        }
-    }
-
-    /// <#Description#>
-    ///
-    /// - Parameter children: <#children description#>
-    /// - Returns: <#return value description#>
-    static internal func parseIndirectAcquisition(children: [XMLElement]) -> [IndirectAcquisition] {
-        var ret = [IndirectAcquisition]()
-
-        for child in children {
-            if let typeAcquisition = child.attributes["type"] {
-                let newIndAcq = IndirectAcquisition(typeAcquisition: typeAcquisition)
-
-                let grandChildren = child.children(tag: "indirectAcquisition")
-                if grandChildren.count > 0 {
-                    newIndAcq.child = parseIndirectAcquisition(children: grandChildren)
-                }
-                ret.append(newIndAcq)
-            }
-        }
-        return ret
-    }
+    
 }

--- a/readium-opdsTests/readium_opds1_1_test.swift
+++ b/readium-opdsTests/readium_opds1_1_test.swift
@@ -29,7 +29,7 @@ class readium_opds1_1_test: XCTestCase {
 
         do {
             let opdsData = try Data(contentsOf: fileURL)
-            feed = try OPDSParser.parse(xmlData: opdsData)
+            feed = try OPDS1Parser.parse(xmlData: opdsData)
             XCTAssert(feed != nil)
         } catch {
             XCTFail(error.localizedDescription)


### PR DESCRIPTION
This PR is related to the issue #16. It doesn't address it totally. Purpose of this PR is to provide an helper method that is able to parse OPDS v1 and v2 feed from a specified URL.

The previous OPDS v1 parser file was renamed from `OPDSParser.swift` to `OPDS1Parser.swift`.
Now, `OPDSParser.swift` file provides only the requested public helper method.