### PR TITLE
Fix a regression where relative URLs were not correctly handled

### DIFF
--- a/readium-opds/OPDS1Parser.swift
+++ b/readium-opds/OPDS1Parser.swift
@@ -82,8 +82,13 @@ public class OPDS1Parser {
     /// Parse an OPDS feed.
     /// Feed can only be v1 (XML).
     /// - parameter xmlData: The xml raw data
+    /// - parameter url: The feed URL (optional)
     /// - Returns: The resulting Feed
-    public static func parse(xmlData: Data) throws -> Feed {
+    public static func parse(xmlData: Data, url: URL? = nil) throws -> Feed {
+        if let url = url {
+            feedURL = url
+        }
+        
         let document = try XMLDocument.init(data: xmlData)
         
         document.definePrefix("thr", defaultNamespace: "http://purl.org/syndication/thread/1.0")

--- a/readium-opds/OPDS2Parser.swift
+++ b/readium-opds/OPDS2Parser.swift
@@ -91,8 +91,13 @@ public class OPDS2Parser {
     /// Parse an OPDS feed.
     /// Feed can only be v2 (JSON).
     /// - parameter jsonData: The json raw data
+    /// - parameter url: The feed URL (optional)
     /// - Returns: The resulting Feed
-    public static func parse(jsonData: Data) throws -> Feed {
+    public static func parse(jsonData: Data, url: URL? = nil) throws -> Feed {
+        
+        if let url = url {
+            feedURL = url
+        }
         
         guard let jsonRoot = try? JSONSerialization.jsonObject(with: jsonData, options: []) else {
             throw OPDS2ParserError.invalidJSON

--- a/readium-opds/OPDSParser.swift
+++ b/readium-opds/OPDSParser.swift
@@ -28,14 +28,11 @@ public enum OPDSParserError: Error {
 
 public class OPDSParser {
     
-    static var feedURL: URL?
-    
     /// Parse an OPDS feed.
     /// Feed can be v1 (XML) or v2 (JSON).
     /// - parameter url: The feed URL
     /// - Returns: A promise with the resulting Feed
     public static func parseURL(url: URL) -> Promise<Feed> {
-        feedURL = url
         
         return Promise<Feed> {fulfill, reject in
             
@@ -55,10 +52,10 @@ public class OPDSParser {
                 
                 // We try to parse as an OPDS v1 feed,
                 // then, if it fails, we try as an OPDS v2 feed.
-                if let feed = try? OPDS1Parser.parse(xmlData: data) {
+                if let feed = try? OPDS1Parser.parse(xmlData: data, url: url) {
                     fulfill(feed)
                 } else {
-                    if let feed = try? OPDS2Parser.parse(jsonData: data) {
+                    if let feed = try? OPDS2Parser.parse(jsonData: data, url: url) {
                         fulfill(feed)
                     } else {
                         // Not a valid OPDS ressource


### PR DESCRIPTION
Fix #25 

`feedURL` property, used to build absolute URL from relative path, was not properly set when using the generic helper parsing method.
