### PR TITLE
Remove OPDS 2.x publication parsing related methods (moved to r2-shared)

### DIFF
--- a/readium-opds/OPDS2Parser.swift
+++ b/readium-opds/OPDS2Parser.swift
@@ -14,15 +14,11 @@ import PromiseKit
 public enum OPDS2ParserError: Error {
     case invalidJSON
     case metadataNotFound
-    case invalidMetadata
     case invalidLink
-    case invalidIndirectAcquisition
     case missingTitle
     case invalidFacet
     case invalidGroup
     case invalidPublication
-    case invalidContributor
-    case invalidCollection
     case invalidNavigation
 
     var localizedDescription: String {
@@ -33,22 +29,14 @@ public enum OPDS2ParserError: Error {
             return "Metadata not found"
         case .missingTitle:
             return "Missing title"
-        case .invalidMetadata:
-            return "Invalid metadata"
         case .invalidLink:
             return "Invalid link"
-        case .invalidIndirectAcquisition:
-            return "Invalid indirect acquisition"
         case .invalidFacet:
             return "Invalid facet"
         case .invalidGroup:
             return "Invalid group"
         case .invalidPublication:
             return "Invalid publication"
-        case .invalidContributor:
-            return "Invalid contributor"
-        case .invalidCollection:
-            return "Invalid collection"
         case .invalidNavigation:
             return "Invalid navigation"
         }
@@ -187,98 +175,6 @@ public class OPDS2Parser {
         }
     }
 
-    static internal func parseLink(linkDict: [String: Any]) throws -> Link {
-        let l = Link()
-        for (k, v) in linkDict {
-            switch k {
-            case "title":
-                l.title = v as? String
-            case "href":
-                l.href = v as? String
-                l.absoluteHref = URLHelper.getAbsolute(href: l.href, base: feedURL)
-            case "type":
-                l.typeLink = v as? String
-            case "rel":
-                if let rel = v as? String {
-                    l.rel = [rel]
-                }
-                else if let rels = v as? [String] {
-                    l.rel = rels
-                }
-            case "height":
-                l.height = v as? Int
-            case "width":
-                l.width = v as? Int
-            case "bitrate":
-                l.bitrate = v as? Int
-            case "duration":
-                l.duration = v as? Double
-            case "templated":
-                l.templated = v as? Bool
-            case "properties":
-                var prop = Properties()
-                if let propDict = v as? [String: Any] {
-                    for (kp, vp) in propDict {
-                        switch kp {
-                        case "numberOfItems":
-                            prop.numberOfItems = vp as? Int
-                        case "indirectAcquisition":
-                            guard let acquisitions = v as? [[String: Any]] else {
-                                throw OPDS2ParserError.invalidLink
-                            }
-                            for a in acquisitions {
-                                let ia = try parseIndirectAcquisition(indirectAcquisitionDict: a)
-                                if prop.indirectAcquisition == nil {
-                                    prop.indirectAcquisition = [ia]
-                                }
-                                else {
-                                    prop.indirectAcquisition!.append(ia)
-                                }
-                            }
-                        case "price":
-                            guard let priceDict = v as? [String: Any],
-                            let currency = priceDict["currency"] as? String,
-                            let value = priceDict["value"] as? Double
-                            else {
-                                throw OPDS2ParserError.invalidLink
-                            }
-                            let price = Price(currency: currency, value: value)
-                            prop.price = price
-                        default:
-                            continue
-                        }
-                    }
-                }
-            case "children":
-                guard let childLinkDict = v as? [String: Any] else {
-                    throw OPDS2ParserError.invalidLink
-                }
-                let childLink = try parseLink(linkDict: childLinkDict)
-                l.children.append(childLink)
-            default:
-                continue
-            }
-        }
-        return l
-    }
-
-    static internal func parseIndirectAcquisition(indirectAcquisitionDict: [String: Any]) throws -> IndirectAcquisition {
-        guard let iaType = indirectAcquisitionDict["type"] as? String else {
-            throw OPDS2ParserError.invalidIndirectAcquisition
-        }
-        let ia = IndirectAcquisition(typeAcquisition: iaType)
-        for (k, v) in indirectAcquisitionDict {
-            if (k == "child") {
-                guard let childDict = v as? [String: Any] else {
-                    throw OPDS2ParserError.invalidIndirectAcquisition
-                }
-                let child = try parseIndirectAcquisition(indirectAcquisitionDict: childDict)
-                ia.child.append(child)
-            }
-        }
-        return ia
-    }
-
     static internal func parseFacets(feed: Feed, facets: [[String: Any]]) throws {
         for facetDict in facets {
             guard let metadata = facetDict["metadata"] as? [String: Any] else {
@@ -295,7 +191,8 @@ public class OPDS2Parser {
                         throw OPDS2ParserError.invalidFacet
                     }
                     for linkDict in links {
-                        let link = try parseLink(linkDict: linkDict)
+                        let link = try Link.parse(linkDict: linkDict)
+                        link.absoluteHref = URLHelper.getAbsolute(href: link.href, base: feedURL)
                         facet.links.append(link)
                     }
                 }
@@ -306,21 +203,23 @@ public class OPDS2Parser {
 
     static internal func parseLinks(feed: Feed, links: [[String: Any]]) throws {
         for linkDict in links {
-            let link = try parseLink(linkDict: linkDict)
+            let link = try Link.parse(linkDict: linkDict)
+            link.absoluteHref = URLHelper.getAbsolute(href: link.href, base: feedURL)
             feed.links.append(link)
         }
     }
 
     static internal func parsePublications(feed: Feed, publications: [[String: Any]]) throws {
         for pubDict in publications {
-            let pub = try parsePublication(pubDict: pubDict)
+            let pub = try Publication.parse(pubDict: pubDict)
             feed.publications.append(pub)
         }
     }
 
     static internal func parseNavigation(feed: Feed, navLinks: [[String: Any]]) throws {
         for navDict in navLinks {
-            let link = try parseLink(linkDict: navDict)
+            let link = try Link.parse(linkDict: navDict)
+            link.absoluteHref = URLHelper.getAbsolute(href: link.href, base: feedURL)
             feed.navigation.append(link)
         }
     }
@@ -345,7 +244,8 @@ public class OPDS2Parser {
                         throw OPDS2ParserError.invalidGroup
                     }
                     for linkDict in links {
-                        let link = try parseLink(linkDict: linkDict)
+                        let link = try Link.parse(linkDict: linkDict)
+                        link.absoluteHref = URLHelper.getAbsolute(href: link.href, base: feedURL)
                         group.links.append(link)
                     }
                 case "navigation":
@@ -353,7 +253,8 @@ public class OPDS2Parser {
                         throw OPDS2ParserError.invalidGroup
                     }
                     for linkDict in links {
-                        let link = try parseLink(linkDict: linkDict)
+                        let link = try Link.parse(linkDict: linkDict)
+                        link.absoluteHref = URLHelper.getAbsolute(href: link.href, base: feedURL)
                         group.navigation.append(link)
                     }
                 case "publications":
@@ -361,7 +262,7 @@ public class OPDS2Parser {
                         throw OPDS2ParserError.invalidGroup
                     }
                     for pubDict in publications {
-                        let publication = try parsePublication(pubDict: pubDict)
+                        let publication = try Publication.parse(pubDict: pubDict)
                         group.publications.append(publication)
                     }
                 default:
@@ -370,246 +271,6 @@ public class OPDS2Parser {
             }
             feed.groups.append(group)
         }
-    }
-
-    static internal func parsePublication(pubDict: [String: Any]) throws -> Publication {
-        let p = Publication()
-        for (k, v) in pubDict {
-            switch k {
-            case "metadata":
-                guard let metadataDict = v as? [String: Any] else {
-                    throw OPDS2ParserError.invalidPublication
-                }
-                let metadata = try parsePublicationMetadata(metadataDict: metadataDict)
-                p.metadata = metadata
-            case "links":
-                guard let links = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidPublication
-                }
-                for linkDict in links {
-                    let link = try parseLink(linkDict: linkDict)
-                    p.links.append(link)
-                }
-            case "images":
-                guard let links = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidPublication
-                }
-                for linkDict in links {
-                    let link = try parseLink(linkDict: linkDict)
-                    p.images.append(link)
-                }
-            default:
-                continue
-            }
-        }
-        return p
-    }
-
-    static internal func parseContributor(_ cDict: [String: Any]) throws -> Contributor {
-        let c = Contributor()
-        for (k, v) in cDict {
-            switch k {
-            case "name":
-                switch v {
-                case let s as String:
-                    c.multilangName.singleString = s
-                case let multiString as [String: String]:
-                    c.multilangName.multiString = multiString
-                default:
-                    throw OPDS2ParserError.invalidContributor
-                }
-            case "identifier":
-                c.identifier = v as? String
-            case "sort_as":
-                c.sortAs = v as? String
-            case "role":
-                if let s = v as? String {
-                    c.roles.append(s)
-                }
-            case "links":
-                if let linkDict = v as? [String: Any] {
-                    c.links.append(try parseLink(linkDict: linkDict))
-                }
-            default:
-                continue
-            }
-        }
-        return c
-    }
-
-    static internal func parseContributors(_ contributors: Any) throws -> [Contributor] {
-        var result: [Contributor] = []
-        switch contributors {
-        case let name as String:
-            let c = Contributor()
-            c.multilangName.singleString = name
-            result.append(c)
-        case let cDict as [String: Any]:
-            let c = try parseContributor(cDict)
-            result.append(c)
-        case let cArray as [[String: Any]]:
-            for cDict in cArray {
-                let c = try parseContributor(cDict)
-                result.append(c)
-            }
-        default:
-            throw OPDS2ParserError.invalidContributor
-        }
-        return result
-    }
-
-    static internal func parseCollection(_ collectionDict: [String: Any]) throws -> R2Shared.Collection {
-        guard let name = collectionDict["name"] as? String else {
-            throw OPDS2ParserError.invalidCollection
-        }
-        let c = R2Shared.Collection(name: name)
-        for (k, v) in collectionDict {
-            switch k {
-            case "name": // Already handled above
-                continue
-            case "sort_as":
-                c.sortAs = v as? String
-            case "identifier":
-                c.identifier = v as? String
-            case "position":
-                c.position = v as? Double
-            case "links":
-                guard let links = v as? [[String: Any]] else {
-                    throw OPDS2ParserError.invalidCollection
-                }
-                for link in links {
-                    c.links.append(try parseLink(linkDict: link))
-                }
-            default:
-                continue
-            }
-        }
-        return c
-    }
-
-    static internal func parsePublicationMetadata(metadataDict: [String: Any]) throws -> Metadata {
-        let m = Metadata()
-        for (k, v) in metadataDict {
-            switch k {
-            case "title":
-                m.multilangTitle = MultilangString()
-                m.multilangTitle?.singleString = v as? String
-            case "identifier":
-                m.identifier = v as? String
-            case "type", "@type":
-                m.rdfType = v as? String
-            case "modified":
-                if let dateStr = v as? String {
-                    m.modified = dateStr.dateFromISO8601
-                }
-            case "author":
-                m.authors.append(contentsOf: try parseContributors(v))
-            case "translator":
-                m.translators.append(contentsOf: try parseContributors(v))
-            case "editor":
-                m.editors.append(contentsOf: try parseContributors(v))
-            case "artist":
-                m.artists.append(contentsOf: try parseContributors(v))
-            case "illustrator":
-                m.illustrators.append(contentsOf: try parseContributors(v))
-            case "letterer":
-                m.letterers.append(contentsOf: try parseContributors(v))
-            case "penciler":
-                m.pencilers.append(contentsOf: try parseContributors(v))
-            case "colorist":
-                m.colorists.append(contentsOf: try parseContributors(v))
-            case "inker":
-                m.inkers.append(contentsOf: try parseContributors(v))
-            case "narrator":
-                m.narrators.append(contentsOf: try parseContributors(v))
-            case "contributor":
-                m.contributors.append(contentsOf: try parseContributors(v))
-            case "publisher":
-                m.publishers.append(contentsOf: try parseContributors(v))
-            case "imprint":
-                m.imprints.append(contentsOf: try parseContributors(v))
-            case "published":
-                m.publicationDate = v as? String
-            case "description":
-                m.description = v as? String
-            case "source":
-                m.source = v as? String
-            case "rights":
-                m.rights = v as? String
-            case "subject":
-                if let subjects = v as? [[String: Any]] {
-                    for subjDict in subjects {
-                        let subject = Subject()
-                        for (sk, sv) in subjDict {
-                            switch sk {
-                            case "name":
-                                subject.name = sv as? String
-                            case "sort_as":
-                                subject.sortAs = sv as? String
-                            case "scheme":
-                                subject.scheme = sv as? String
-                            case "code":
-                                subject.code = sv as? String
-                            default:
-                                continue
-                            }
-                        }
-                        m.subjects.append(subject)
-                    }
-                }
-            case "belongs_to":
-                if let belongsDict = v as? [String: Any] {
-                    let belongs = BelongsTo()
-                    for (bk, bv) in belongsDict {
-                        switch bk {
-                        case "series":
-                            switch bv {
-                            case let s as String:
-                                belongs.series.append(R2Shared.Collection(name: s))
-                            case let cArr as [[String: Any]]:
-                                for cDict in cArr {
-                                    belongs.series.append(try parseCollection(cDict))
-                                }
-                            case let cDict as [String: Any]:
-                                belongs.series.append(try parseCollection(cDict))
-                            default:
-                                continue
-                            }
-                        case "collection":
-                            switch bv {
-                            case let s as String:
-                                belongs.collection.append(R2Shared.Collection(name: s))
-                            case let cArr as [[String: Any]]:
-                                for cDict in cArr {
-                                    belongs.collection.append(try parseCollection(cDict))
-                                }
-                            case let cDict as [String: Any]:
-                                belongs.collection.append(try parseCollection(cDict))
-                            default:
-                                continue
-                            }
-                        default:
-                            continue
-                        }
-                    }
-                    m.belongsTo = belongs
-                }
-            case "duration":
-                m.duration = v as? Int
-            case "language":
-                switch v {
-                case let s as String:
-                    m.languages.append(s)
-                case let sArr as [String]:
-                    m.languages.append(contentsOf: sArr)
-                default:
-                    continue
-                }
-            default:
-                continue
-            }
-        }
-        return m
     }
 
 }


### PR DESCRIPTION
Fix #13 - Must be merge with PR readium/r2-shared-swift#13

This PR removes following methods from `OPDS2Parser`:

`static internal func parsePublication(pubDict: [String: Any]) throws`
`static internal func parsePublicationMetadata(metadataDict: [String: Any]) throws -> Metadata`
`static internal func parseContributors(_ contributors: Any) throws -> [Contributor]`
`static internal func parseContributor(_ cDict: [String: Any]) throws -> Contributor`
`static internal func parseCollection(_ collectionDict: [String: Any]) throws -> R2Shared.Collection`
`static internal func parseLink(linkDict: [String: Any]) throws -> Link`
`static internal func parseIndirectAcquisition(indirectAcquisitionDict: [String: Any]) throws -> IndirectAcquisition`