### PR TITLE
OPDS Parser will now returns a intermediate structure

### DIFF
--- a/readium-opds.xcodeproj/project.pbxproj
+++ b/readium-opds.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		111E54DF2022812B00A7FE9A /* opds_2_0.json in Resources */ = {isa = PBXBuildFile; fileRef = 111E54DE2022812B00A7FE9A /* opds_2_0.json */; };
 		111E54E12022816000A7FE9A /* readium_opds2_0_test.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111E54E02022816000A7FE9A /* readium_opds2_0_test.swift */; };
 		AE0AC4A620AB1F8B00B2FC36 /* Fuzi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AE0AC4A520AB1F8B00B2FC36 /* Fuzi.framework */; };
+		AE49834720D902710013B912 /* ParseData.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE49834620D902710013B912 /* ParseData.swift */; };
 		AE6B98E020CAB93200117197 /* OPDSParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6B98DF20CAB93200117197 /* OPDSParser.swift */; };
 		AED681F020A316160090DBCD /* URLHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = AED681EF20A316160090DBCD /* URLHelper.swift */; };
 		F34B7E571FA35B7900534FD3 /* ReadiumOPDS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F34B7E4D1FA35B7900534FD3 /* ReadiumOPDS.framework */; };
@@ -45,6 +46,7 @@
 		111E54DE2022812B00A7FE9A /* opds_2_0.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; name = opds_2_0.json; path = "readium-opdsTests/Samples/opds_2_0.json"; sourceTree = SOURCE_ROOT; };
 		111E54E02022816000A7FE9A /* readium_opds2_0_test.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = readium_opds2_0_test.swift; sourceTree = "<group>"; };
 		AE0AC4A520AB1F8B00B2FC36 /* Fuzi.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fuzi.framework; path = Carthage/Build/iOS/Fuzi.framework; sourceTree = "<group>"; };
+		AE49834620D902710013B912 /* ParseData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ParseData.swift; sourceTree = "<group>"; };
 		AE6B98DF20CAB93200117197 /* OPDSParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OPDSParser.swift; sourceTree = "<group>"; };
 		AED681EF20A316160090DBCD /* URLHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLHelper.swift; sourceTree = "<group>"; };
 		F34B7E4D1FA35B7900534FD3 /* ReadiumOPDS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ReadiumOPDS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -119,6 +121,7 @@
 				F34B7E681FA35BB100534FD3 /* OPDS1Parser.swift */,
 				111E54DB2021022700A7FE9A /* OPDS2Parser.swift */,
 				AED681EF20A316160090DBCD /* URLHelper.swift */,
+				AE49834620D902710013B912 /* ParseData.swift */,
 			);
 			path = "readium-opds";
 			sourceTree = "<group>";
@@ -286,6 +289,7 @@
 				AED681F020A316160090DBCD /* URLHelper.swift in Sources */,
 				F34B7E691FA35BB100534FD3 /* OPDS1Parser.swift in Sources */,
 				AE6B98E020CAB93200117197 /* OPDSParser.swift in Sources */,
+				AE49834720D902710013B912 /* ParseData.swift in Sources */,
 				111E54DC2021022700A7FE9A /* OPDS2Parser.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/readium-opds/OPDS2Parser.swift
+++ b/readium-opds/OPDS2Parser.swift
@@ -77,7 +77,7 @@ public class OPDS2Parser {
     }
     
     /// Parse an OPDS feed or publication.
-    /// Feed can only be v1 (XML).
+    /// Feed can only be v2 (JSON).
     /// - parameter jsonData: The json raw data
     /// - parameter url: The feed URL
     /// - parameter response: The response payload

--- a/readium-opds/OPDSParser.swift
+++ b/readium-opds/OPDSParser.swift
@@ -28,13 +28,16 @@ public enum OPDSParserError: Error {
 
 public class OPDSParser {
     
-    /// Parse an OPDS feed.
+    static var feedURL: URL?
+    
+    /// Parse an OPDS feed or publication.
     /// Feed can be v1 (XML) or v2 (JSON).
     /// - parameter url: The feed URL
-    /// - Returns: A promise with the resulting Feed
-    public static func parseURL(url: URL) -> Promise<Feed> {
+    /// - Returns: A promise with the intermediate structure of type ParseData
+    public static func parseURL(url: URL) -> Promise<ParseData> {
+        feedURL = url
         
-        return Promise<Feed> {fulfill, reject in
+        return Promise<ParseData> {fulfill, reject in
             
             let task = URLSession.shared.dataTask(with: url, completionHandler: { (data, response, error) in
                 
@@ -52,11 +55,11 @@ public class OPDSParser {
                 
                 // We try to parse as an OPDS v1 feed,
                 // then, if it fails, we try as an OPDS v2 feed.
-                if let feed = try? OPDS1Parser.parse(xmlData: data, url: url) {
-                    fulfill(feed)
+                if let parseData = try? OPDS1Parser.parse(xmlData: data, url: url, response: response!) {
+                    fulfill(parseData)
                 } else {
-                    if let feed = try? OPDS2Parser.parse(jsonData: data, url: url) {
-                        fulfill(feed)
+                    if let parseData = try? OPDS2Parser.parse(jsonData: data, url: url, response: response!) {
+                        fulfill(parseData)
                     } else {
                         // Not a valid OPDS ressource
                         reject(OPDSParserError.documentNotValid)

--- a/readium-opds/ParseData.swift
+++ b/readium-opds/ParseData.swift
@@ -1,0 +1,55 @@
+//
+//  ParseData.swift
+//  readium-opds
+//
+//  Created by Geoffrey Bugniot on 14/06/2018.
+//  Copyright © 2018 Readium. All rights reserved.
+//
+
+import Foundation
+import R2Shared
+
+/// List of OPDS versions compliant with the parser.
+public enum Version {
+    /// OPDS 1.x must be an XML ressource
+    case OPDS1
+    /// OPDS 1.x must be a JSON ressource
+    case OPDS2
+}
+
+/// An intermediate structure return when the generic helper method public static
+/// func parseURL(url: URL) -> Promise<ParseData> from OPDSParser class is called.
+public struct ParseData {
+    
+    /// The ressource URL
+    public var url: URL
+    
+    /// The URLResponse got after fetching the ressource
+    public var response: URLResponse
+    
+    /// The OPDS version
+    public var version: Version
+    
+    /// The feed
+    public var feed: Feed? {
+        didSet {
+            // Publication is nil when feed is not
+            if feed != nil { publication = nil }
+        }
+    }
+    
+    /// The publication
+    public var publication: Publication? {
+        didSet {
+            // Feed is nil when publication is not
+            if publication != nil { feed = nil }
+        }
+    }
+    
+    init(url: URL, response: URLResponse, version: Version) {
+        self.url = url
+        self.response = response
+        self.version = version
+    }
+    
+}

--- a/readium-opds/ParseData.swift
+++ b/readium-opds/ParseData.swift
@@ -13,7 +13,7 @@ import R2Shared
 public enum Version {
     /// OPDS 1.x must be an XML ressource
     case OPDS1
-    /// OPDS 1.x must be a JSON ressource
+    /// OPDS 2.x must be a JSON ressource
     case OPDS2
 }
 


### PR DESCRIPTION
Fix #16 - Add helper method to handle OPDS 1.x/2.0 parsing (*intermediate structure*)

OPDS Parser will now returns a intermediate structure with: 
- `feed` XOR `publication`
- `version`
- `url`
- `response` (URLResponse: payload + headers)